### PR TITLE
50 create set up page allocator in kernelc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ LINKER		:= linker.ld
 INCLUDES	:= includes
 SRCS_DIR	:= srcs/
 ASMSRCS		:= boot.s init_seg.s
-SRCS		:= kernel.c terminal.c utils.c vga.c printf.c keyboard.c debug.c reboot.c gdt.c panic.c init.c mm.c memory.c
+SRCS		:= kernel.c terminal.c utils.c vga.c printf.c keyboard.c debug.c reboot.c gdt.c panic.c init.c mm.c memory.c \
+				ordered_array.c
 OBJS_DIR	:= objs/
 OBJSNAME	:= $(SRCS:.c=.o)
 OBJS		:= $(SRCS:%.c=$(OBJS_DIR)%.o)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LINKER		:= linker.ld
 INCLUDES	:= includes
 SRCS_DIR	:= srcs/
 ASMSRCS		:= boot.s init_seg.s
-SRCS		:= kernel.c terminal.c utils.c vga.c printf.c keyboard.c debug.c reboot.c gdt.c panic.c init.c mm.c
+SRCS		:= kernel.c terminal.c utils.c vga.c printf.c keyboard.c debug.c reboot.c gdt.c panic.c init.c mm.c memory.c
 OBJS_DIR	:= objs/
 OBJSNAME	:= $(SRCS:.c=.o)
 OBJS		:= $(SRCS:%.c=$(OBJS_DIR)%.o)

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -36,10 +36,13 @@ typedef struct page_dir
 extern struct meminfo mmi;
 extern uint32_t _kernel_end;
 
-void mem_init();
-void set_bit(uint32_t addr);
-void unset_bit(uint32_t addr);
-uint32_t test_bit(uint32_t addr);
-uint32_t bitmap_alloc(uint32_t size);
+void		mem_init();
+void		set_bit(uint32_t addr);
+void		unset_bit(uint32_t addr);
+uint32_t	test_bit(uint32_t addr);
+uint32_t	var_partion(uint32_t size);
+uint32_t	get_frame();
+void		alloc_frame(uint32_t *page);
+uint32_t	*get_page(uint32_t addr);
 
 #endif

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -2,6 +2,7 @@
 # define _MM_H
 
 #include <stdint.h>
+#include "ordered_array.h"
 
 # define KERNEL_BASE 0xC0000000
 # define SHIFT 12
@@ -12,6 +13,9 @@
 # define V2P(x) (((uint32_t) x) - KERNEL_BASE)
 #define IDX_FRAME(a) (a/(4*8))
 #define OFFSET_FRAME(a) (a%(4*8))
+#define ALIGN(a) if (a & 0x00000FFF) { a &= 0xFFFFF000; a += 0x1000; }
+#define ARRAY_IDX_SIZE 0x20000
+#define HEAP_MAGIC 0xBABA1EFF
 
 struct meminfo
 {
@@ -33,6 +37,29 @@ typedef struct page_dir
 	uint32_t entries[1024];
 } page_dir_t;
 
+typedef struct
+{
+	ordered_array_t	arr;
+	uint32_t		start_addr;
+	uint32_t		end_addr;
+	uint32_t		max_addr;
+	uint8_t			is_user; // 1 ? user: kernel;
+	uint8_t			is_write; // 1 ? rw : r;
+} heap_t;
+
+typedef struct
+{
+	uint8_t is_hole;
+	uint32_t magic;
+	uint32_t size;
+} header_t;
+
+typedef struct
+{
+	uint32_t header;
+	uint32_t magic;
+} footer_t;
+
 extern struct meminfo mmi;
 extern uint32_t _kernel_end;
 
@@ -44,5 +71,6 @@ uint32_t	var_partition(uint32_t size);
 uint32_t	get_frame();
 void		alloc_frame(uint32_t *page);
 uint32_t	*get_page(uint32_t addr);
+heap_t		*init_heap(uint32_t size, uint32_t max_addr, uint8_t is_user, uint8_t is_write);
 
 #endif

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -40,7 +40,7 @@ void		mem_init();
 void		set_bit(uint32_t addr);
 void		unset_bit(uint32_t addr);
 uint32_t	test_bit(uint32_t addr);
-uint32_t	var_partion(uint32_t size);
+uint32_t	var_partition(uint32_t size);
 uint32_t	get_frame();
 void		alloc_frame(uint32_t *page);
 uint32_t	*get_page(uint32_t addr);

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -8,8 +8,10 @@
 # define PAGE_SIZE 4096
 # define PAGE_MASK (~(PAGE_SIZE - 1))
 # define PAGING20(x) (uint32_t) (x & ~PAGE_MASK)
-# define P2V(x) (uint32_t) (x + KERNEL_BASE)
-# define V2P(x) (uint32_t) (x - KERNEL_BASE)
+# define P2V(x) (((uint32_t) x) + KERNEL_BASE)
+# define V2P(x) (((uint32_t) x) - KERNEL_BASE)
+#define IDX_FRAME(a) (a/(4*8))
+#define OFFSET_FRAME(a) (a%(4*8))
 
 struct meminfo
 {
@@ -21,9 +23,23 @@ struct meminfo
 	uint32_t	nframes;
 };
 
+typedef struct page_tbl
+{
+	uint32_t entries[1024];
+} page_tbl_t;
+
+typedef struct page_dir
+{
+	uint32_t entries[1024];
+} page_dir_t;
+
 extern struct meminfo mmi;
-extern char _kernel_end;
+extern uint32_t _kernel_end;
 
 void mem_init();
+void set_bit(uint32_t addr);
+void unset_bit(uint32_t addr);
+uint32_t test_bit(uint32_t addr);
+uint32_t bitmap_alloc(uint32_t size);
 
 #endif

--- a/includes/ordered_array.h
+++ b/includes/ordered_array.h
@@ -13,5 +13,7 @@ typedef struct ordered_array
 } ordered_array_t;
 
 ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_predic_t less);
+void insert_ordered_array(type_t item, ordered_array_t *arr);
+type_t select_ordered_array(uint32_t idx, ordered_array_t *arr);
 
 #endif

--- a/includes/ordered_array.h
+++ b/includes/ordered_array.h
@@ -1,0 +1,17 @@
+#ifndef _ORDERED_ARRAY
+# define _ORDERED_ARRAY
+
+#include <stdint.h>
+typedef void* type_t;
+typedef int8_t		(*lessthan_predic_t)(void*, void*);
+typedef struct ordered_array
+{
+	type_t				*arr;
+	uint32_t			size;
+	uint32_t			max_size;
+	lessthan_predic_t	lessthan;
+} ordered_array_t;
+
+ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_predic_t less);
+
+#endif

--- a/includes/panic.h
+++ b/includes/panic.h
@@ -4,5 +4,6 @@
 #include <stddef.h>
 
 void panic(const char*, size_t);
+void panic_1(const char*);
 
 #endif

--- a/srcs/kernel.c
+++ b/srcs/kernel.c
@@ -63,7 +63,7 @@ void kernel_main(unsigned long addr)
 {
 	// init_gdt();
 	terminal_initialize();
-	mem_init();
 	parse_bootinfo(P2V(addr));
+	mem_init();
 	init();
 }

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -41,11 +41,14 @@ uint32_t get_frame() // find frame
 	uint32_t idx, off;
 	for (idx = 0; idx < IDX_FRAME(mmi.nframes); idx++)
 	{
-		for (off = 0; off < 32; off++)
+		if (mmi.frames[idx] != 0xffffffff)
 		{
-			uint32_t tmp = 0x1 << off;
-			if ((mmi.frames[idx] & tmp) == 0)
-				return idx*32+off;
+			for (off = 0; off < 32; off++)
+			{
+				uint32_t tmp = 0x1 << off;
+				if ((mmi.frames[idx] & tmp) == 0)
+					return idx*32+off;
+			}
 		}
 	}
 	return (uint32_t)-1;

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -79,7 +79,7 @@ uint32_t *get_page(uint32_t addr)
 	uint32_t dir_off = addr >> (SHIFT + 10);
 	if (!pgdir->entries[dir_off]) // 테이블이 없는 경우
 	{
-		uint32_t tmp = var_partion(sizeof(page_tbl_t)); // TODO kmalloc
+		uint32_t tmp = var_partition(sizeof(page_tbl_t)); // TODO kmalloc
 		pgdir->entries[dir_off] = V2P(tmp) | 0x3;
 		memset(pgdir->entries[dir_off], 0, 0x1000U);
 	}

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -2,13 +2,10 @@
 #include "utils.h"
 #include "panic.h"
 
-#define IDX_FRAME(a) (a/(4*8))
-#define OFFSET_FRAME(a) (a%(4*8))
-
 uint32_t placement = &_kernel_end;
 struct meminfo mmi;
 
-static void set_bit(uint32_t addr)
+void set_bit(uint32_t addr)
 {
 	uint32_t frame = addr / 0x1000;
 	uint32_t idx = IDX_FRAME(frame);
@@ -16,7 +13,7 @@ static void set_bit(uint32_t addr)
 	mmi.frames[idx] |= (0x1 << off);
 }
 
-static void unset_bit(uint32_t addr)
+void unset_bit(uint32_t addr)
 {
 	uint32_t frame = addr / 0x1000;
 	uint32_t idx = IDX_FRAME(frame);
@@ -24,7 +21,7 @@ static void unset_bit(uint32_t addr)
 	mmi.frames[idx] &= ~(0x1 << off);
 }
 
-static uint32_t test_bit(uint32_t addr)
+uint32_t test_bit(uint32_t addr)
 {
 	uint32_t frame = addr / 0x1000;
 	uint32_t idx = IDX_FRAME(frame);
@@ -38,4 +35,3 @@ uint32_t bitmap_alloc(uint32_t size)
 	placement += size;
 	return start;
 }
-

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -2,8 +2,8 @@
 #include "utils.h"
 #include "panic.h"
 
+extern page_dir_t *pgdir;
 uint32_t placement = &_kernel_end;
-struct meminfo mmi;
 
 void set_bit(uint32_t addr)
 {
@@ -29,9 +29,59 @@ uint32_t test_bit(uint32_t addr)
 	return (mmi.frames[idx] & (0x1 << off));
 }
 
-uint32_t bitmap_alloc(uint32_t size)
+uint32_t var_partition(uint32_t size)
 {
 	uint32_t start = placement;
 	placement += size;
 	return start;
+}
+
+uint32_t get_frame() // find frame
+{
+	uint32_t idx, off;
+	for (idx = 0; idx < IDX_FRAME(mmi.nframes); idx++)
+	{
+		for (off = 0; off < 32; off++)
+		{
+			uint32_t tmp = 0x1 << off;
+			if ((mmi.frames[idx] & tmp) == 0)
+				return idx*32+off;
+		}
+	}
+	return (uint32_t)-1;
+}
+
+void alloc_frame(uint32_t *page) // mapping page to frame
+{
+	if (*page == 0) // page에 아무런 내용이 없으면
+	{
+		uint32_t frame = get_frame();
+		if (frame == (uint32_t)-1)
+		{
+			panic("no frame\n", strlen("no frame\n"));
+		}
+		set_bit(frame * 0x1000U);
+		*page = (frame * 0x1000U) | 0x3;
+	}
+}
+
+static uint32_t *_page(uint32_t addr)
+{
+	uint32_t addr20 = addr >> SHIFT;
+	uint32_t dir_off = addr20 >> 10;
+	uint32_t tbl_off = addr20 & 0x3ff;
+	page_tbl_t *table = P2V(pgdir->entries[dir_off] & (~0xfff)); // 엔트리에 물리 주소가 저장되어 있으므로 
+	return &table->entries[tbl_off];
+}
+
+uint32_t *get_page(uint32_t addr)
+{
+	uint32_t dir_off = addr >> (SHIFT + 10);
+	if (!pgdir->entries[dir_off]) // 테이블이 없는 경우
+	{
+		uint32_t tmp = var_partion(sizeof(page_tbl_t)); // TODO kmalloc
+		pgdir->entries[dir_off] = V2P(tmp) | 0x3;
+		memset(pgdir->entries[dir_off], 0, 0x1000U);
+	}
+	return _page(addr);
 }

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -1,15 +1,41 @@
+#include "../includes/mm.h"
+#include "utils.h"
+#include "panic.h"
 
-unsigned long *pg_dir;
-unsigned long *pg_tbl;
+#define IDX_FRAME(a) (a/(4*8))
+#define OFFSET_FRAME(a) (a%(4*8))
 
-void paging_init()
+uint32_t placement = &_kernel_end;
+struct meminfo mmi;
+
+static void set_bit(uint32_t addr)
 {
-	for(unsigned i = 0; i < 1024; i++)
-	{
-		pg_dir[i] = (unsigned long)(pg_tbl + 1024 * i) | 0x3;
-	}
-	for(unsigned i = 0; i < 1024; i++)
-	{
-		pg_tbl[i] = (i * 0x1000) | 0x1;
-	}
+	uint32_t frame = addr / 0x1000;
+	uint32_t idx = IDX_FRAME(frame);
+	uint32_t off = OFFSET_FRAME(frame);
+	mmi.frames[idx] |= (0x1 << off);
 }
+
+static void unset_bit(uint32_t addr)
+{
+	uint32_t frame = addr / 0x1000;
+	uint32_t idx = IDX_FRAME(frame);
+	uint32_t off = OFFSET_FRAME(frame);
+	mmi.frames[idx] &= ~(0x1 << off);
+}
+
+static uint32_t test_bit(uint32_t addr)
+{
+	uint32_t frame = addr / 0x1000;
+	uint32_t idx = IDX_FRAME(frame);
+	uint32_t off = OFFSET_FRAME(frame);
+	return (mmi.frames[idx] & (0x1 << off));
+}
+
+uint32_t bitmap_alloc(uint32_t size)
+{
+	uint32_t start = placement;
+	placement += size;
+	return start;
+}
+

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -1,6 +1,7 @@
 #include "../includes/mm.h"
 #include "utils.h"
 #include "panic.h"
+#include "ordered_array.h"
 
 extern page_dir_t *pgdir;
 uint32_t placement = &_kernel_end;
@@ -87,4 +88,38 @@ uint32_t *get_page(uint32_t addr)
 		memset(pgdir->entries[dir_off], 0, 0x1000U);
 	}
 	return _page(addr);
+}
+
+static int8_t header_lessthan(void *a, void *b)
+{
+	return ((header_t *)a)->size < ((header_t *)b)->size;
+}
+
+heap_t *init_heap(uint32_t size, uint32_t max_addr, uint8_t is_user, uint8_t is_write)
+{
+	heap_t *heap = (heap_t *)var_partition(sizeof(heap_t));
+	uint32_t arr_addr = var_partition(sizeof(type_t) * ARRAY_IDX_SIZE);
+
+	heap->arr = init_ordered_array((void *)arr_addr, ARRAY_IDX_SIZE, header_lessthan);
+	// arr_addr 영역 이후 부터 메모리 할당이 가능한 지점
+	arr_addr += (sizeof(type_t) * ARRAY_IDX_SIZE);
+	 // 페이지 4K를 위한 주소값 지정
+	ALIGN(arr_addr);
+	// heap에 할당 가능한 공간의 정보 초기화
+	heap->start_addr = arr_addr;
+	heap->end_addr = arr_addr + size;
+	heap->max_addr = max_addr;
+	heap->is_user = is_user;
+	heap->is_write = is_write;
+	// ordered_array 에 저장할 첫 번째 hole의 header와 footer
+	header_t *first_hole = (header_t *)heap->start_addr;
+	first_hole->size = size;
+	first_hole->magic = HEAP_MAGIC;
+	first_hole->is_hole = 1;
+	footer_t *footer = (footer_t *)(heap->end_addr - sizeof(footer_t));
+	footer->header = first_hole;
+	footer->magic = HEAP_MAGIC;
+	insert_ordered_array((type_t)first_hole, &heap->arr);
+
+	return heap;
 }

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -41,5 +41,5 @@ void mem_init()
 		set_bit(i * 0x1000U);
 	}
 	// test();
-	kheap = init_heap(0x10000, 0xFFFFFFFF, 0, 1);
+	kheap = init_heap(0x10000, 0xFFFFE000, 0, 1);
 }

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -1,9 +1,16 @@
 #include "../includes/mm.h"
+#include "utils.h"
 
+extern uint32_t _mapping_size;
 struct meminfo mmi;
 
 void mem_init()
 {
-	mmi.frames = &_kernel_end;
-	mmi.nframes = mmi.totsz >> 12;
+	mmi.nframes = mmi.totsz / 0x1000;
+	mmi.frames = bitmap_alloc(IDX_FRAME(mmi.nframes));
+	memset(mmi.frames, 0, IDX_FRAME(mmi.nframes));
+	for (uint32_t i = 0x0; i < (uint32_t)&_mapping_size; i += 0x1000U)
+	{
+		set_bit(i);
+	}
 }

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -2,7 +2,31 @@
 #include "utils.h"
 
 extern uint32_t _mapping_size;
+extern uint32_t boot_page_directory;
 struct meminfo mmi;
+page_dir_t *pgdir = &boot_page_directory;
+
+void test()
+{
+	printf("%x\n", pgdir);
+	uint32_t i;
+	for (i = 0; i < 1024; i++) // 디렉토리에서 테이블 할당 여부 찾기
+	{ 
+		if (pgdir->entries[i]) 
+		{
+			printf("%x\n", pgdir->entries[i]);
+			break ;
+		}
+	}
+	page_tbl_t *tmp = P2V(pgdir->entries[0x300] & (~0xfff));
+	for (uint32_t i = 0; i < 1024; i++) // 테이블에서 프레임 할당 여부 찾기
+	{ 
+		if (tmp->entries[i]) {
+			printf("%x %x\n",i, tmp->entries[i]);
+		}
+		break ;
+	}
+}
 
 void mem_init()
 {
@@ -13,4 +37,5 @@ void mem_init()
 	{
 		set_bit(i);
 	}
+	test();
 }

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -26,12 +26,14 @@ void test()
 		}
 		break ;
 	}
+	alloc_frame(get_page(0xC0210000));
+	alloc_frame(get_page(0xC0201000));
 }
 
 void mem_init()
 {
 	mmi.nframes = mmi.totsz / 0x1000;
-	mmi.frames = bitmap_alloc(IDX_FRAME(mmi.nframes));
+	mmi.frames = var_partion(IDX_FRAME(mmi.nframes));
 	memset(mmi.frames, 0, IDX_FRAME(mmi.nframes));
 	for (uint32_t i = 0x0; i < (uint32_t)&_mapping_size; i += 0x1000U)
 	{

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -33,7 +33,7 @@ void test()
 void mem_init()
 {
 	mmi.nframes = mmi.totsz / 0x1000;
-	mmi.frames = var_partion(IDX_FRAME(mmi.nframes));
+	mmi.frames = var_partition(IDX_FRAME(mmi.nframes));
 	memset(mmi.frames, 0, IDX_FRAME(mmi.nframes));
 	for (uint32_t i = 0x0; i < (uint32_t)&_mapping_size; i += 0x1000U)
 	{

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -5,6 +5,7 @@ extern uint32_t _mapping_size;
 extern uint32_t boot_page_directory;
 struct meminfo mmi;
 page_dir_t *pgdir = &boot_page_directory;
+heap_t *kheap = 0;
 
 void test()
 {
@@ -37,7 +38,8 @@ void mem_init()
 	memset(mmi.frames, 0, IDX_FRAME(mmi.nframes));
 	for (uint32_t i = 0x0; i < (uint32_t)&_mapping_size; i += 0x1000U)
 	{
-		set_bit(i);
+		set_bit(i * 0x1000U);
 	}
-	test();
+	// test();
+	kheap = init_heap(0x10000, 0xFFFFFFFF, 0, 1);
 }

--- a/srcs/ordered_array.c
+++ b/srcs/ordered_array.c
@@ -1,0 +1,13 @@
+#include "ordered_array.h"
+#include "utils.h"
+
+ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_predic_t less)
+{
+	ordered_array_t new;
+	new.arr = (type_t *)start;
+	memset(new.arr, 0, max_size*sizeof(type_t));
+	new.size = 0;
+	new.max_size = max_size;
+	new.lessthan = less;
+	return new;
+}

--- a/srcs/ordered_array.c
+++ b/srcs/ordered_array.c
@@ -1,5 +1,6 @@
 #include "ordered_array.h"
 #include "utils.h"
+#include "panic.h"
 
 ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_predic_t less)
 {
@@ -10,4 +11,33 @@ ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_pred
 	new.max_size = max_size;
 	new.lessthan = less;
 	return new;
+}
+
+void insert_ordered_array(type_t item, ordered_array_t *arr)
+{
+	uint32_t iterator = 0;
+	while (iterator < arr->size && arr->lessthan(arr->arr[iterator], item))
+		iterator++;
+	if (iterator == arr->size)
+		arr->arr[arr->size++] = item;
+	else
+	{
+		type_t tmp = arr->arr[iterator];
+		arr->arr[iterator] = item;
+		while (iterator < arr->size)
+		{
+			iterator++;
+			type_t tmp2 = arr->arr[iterator];
+			arr->arr[iterator] = tmp;
+			tmp = tmp2;
+		}
+		arr->size++;
+	}
+}
+
+type_t select_ordered_array(uint32_t idx, ordered_array_t *arr)
+{
+	if (idx >= arr->size) // for debug
+		panic_1("check arr_size, idx");
+	return arr->arr[idx];
 }

--- a/srcs/panic.c
+++ b/srcs/panic.c
@@ -1,4 +1,5 @@
 #include "terminal.h"
+#include "utils.h"
 
 void panic(const char* msg, size_t size)
 {
@@ -6,4 +7,9 @@ void panic(const char* msg, size_t size)
 	terminal_write(msg, size);
 	for (;;)
 		;
+}
+
+void panic_1(const char* msg)
+{
+	panic(msg, strlen(msg));
 }


### PR DESCRIPTION
#49 
1. boot 단계에서 페이지와 맵핑한 프레임들에 대해서
  - mmi.frames(프레임 맵핑여부; 비트맵), 비트맵 공간 확보
  - alloc_frame : get_page + get_frame (페이지에 프레임 정보 입력)
  - get_frame : 사용가능한 프레임 찾기
  - get_page : 테이블이 없으면 생성 후, 페이지 반환
  - _page : 입력된 가상 주소를 통해 디렉토리 오프셋, 테이블 오프셋 계산 후 페이지 포인터 반환
 
2. 메모리 관리를 위한 정보 초기화
  - heap
    - arr : ordered_array 입력
    - start_addr : 할당 가능한 시작 주소

  - ordered_array : 정렬된 배열 ( header의 담긴 크기를 비교 후 배열에 insert )
    - arr : type_t 인 배열의 포인터
    - init
    - insert
    - select

***_kernel_end 지점 부터 비트맵 공간, heap 구조체 공간, ordered_array 배열 공간, 메모리 할당 가능한 공간으로 구성***