### PR TITLE
56 fix 페이지 테이블 위치 정보

### DIFF
--- a/includes/mm.h
+++ b/includes/mm.h
@@ -34,7 +34,8 @@ typedef struct page_tbl
 
 typedef struct page_dir
 {
-	uint32_t entries[1024];
+	uint32_t entries[1024]; // physical_addr
+	page_tbl_t *tables[1024]; // virtual_addr
 } page_dir_t;
 
 typedef struct

--- a/srcs/asm/boot.s
+++ b/srcs/asm/boot.s
@@ -38,6 +38,7 @@ _start42:
 3:
 	movl $(boot_page_table1 - 0xC0000000 + 0x003), boot_page_directory - 0xC0000000 + 0 // identity mapping
 	movl $(boot_page_table1 - 0xC0000000 + 0x003), boot_page_directory - 0xC0000000 + 0x300 * 4
+	movl $(boot_page_table1), boot_page_directory - 0xC0000000 + 0x1000 + 0x300 * 4 // pgdir->tables[0x300] = boot_page_table1
 
 	movl $(boot_page_directory - 0xC0000000), %ecx
 	movl %ecx, %cr3
@@ -59,7 +60,7 @@ stack_top:
 .section .bss, "a"
 	.align 4096
 boot_page_directory:
-	.skip 4096
+	.skip 0x2000
 boot_page_table1:
 	.skip 4096
 

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -69,25 +69,18 @@ void alloc_frame(uint32_t *page) // mapping page to frame
 	}
 }
 
-static uint32_t *_page(uint32_t addr)
+uint32_t *get_page(uint32_t addr)
 {
 	uint32_t addr20 = addr >> SHIFT;
 	uint32_t dir_off = addr20 >> 10;
 	uint32_t tbl_off = addr20 & 0x3ff;
-	page_tbl_t *table = P2V(pgdir->entries[dir_off] & (~0xfff)); // 엔트리에 물리 주소가 저장되어 있으므로 
-	return &table->entries[tbl_off];
-}
-
-uint32_t *get_page(uint32_t addr)
-{
-	uint32_t dir_off = addr >> (SHIFT + 10);
-	if (!pgdir->entries[dir_off]) // 테이블이 없는 경우
+	if (!pgdir->tables[dir_off]) // 테이블이 없는 경우
 	{
 		uint32_t tmp = var_partition(sizeof(page_tbl_t)); // TODO kmalloc
 		pgdir->entries[dir_off] = V2P(tmp) | 0x3;
 		memset(pgdir->entries[dir_off], 0, 0x1000U);
 	}
-	return _page(addr);
+	return &(pgdir->tables[dir_off]->entries[tbl_off]);
 }
 
 static int8_t header_lessthan(void *a, void *b)

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -15,17 +15,14 @@ void test()
 	{ 
 		if (pgdir->entries[i]) 
 		{
-			printf("%x\n", pgdir->entries[i]);
+			printf("%x : %x\n", i, pgdir->entries[i]);
 			break ;
 		}
 	}
-	page_tbl_t *tmp = P2V(pgdir->entries[0x300] & (~0xfff));
-	for (uint32_t i = 0; i < 1024; i++) // 테이블에서 프레임 할당 여부 찾기
+	page_tbl_t *tmp = pgdir->tables[0x300];
+	for (uint32_t i = 0; i < 10; i++) // 테이블에서 프레임 할당 여부 찾기
 	{ 
-		if (tmp->entries[i]) {
 			printf("%x %x\n",i, tmp->entries[i]);
-		}
-		break ;
 	}
 	alloc_frame(get_page(0xC0210000));
 	alloc_frame(get_page(0xC0201000));


### PR DESCRIPTION
- 기존에는 P2V/V2P 방식으로 테이블의 물리 주소나 가상 주소를 알아내는 방식이었고, 페이지 테이블이 생성될 위치 범위가 지정되었을 때, 계획했던 방식이었음. 
- 페이지 테이블이 생성될 위치를 지정하지 않는다면 P2V/V2P 으로 페이지 테이블 접근 불가능
- 이에 따라 기존 구조체에 테이블 포인터 변수 추가

### 변경 사항
- 기존 구조체 page_dir_t -> 페이지 테이블[1024] 포인터 변수 추가
- boot.s 
  - boot_page_directory 4096(0x1000) -> 0x2000으로 변경
  - pgdir->tables[0x300] = boot_page_table1 추가