### PR TITLE
feat: memory allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ INCLUDES	:= includes
 SRCS_DIR	:= srcs/
 ASMSRCS		:= boot.s init_seg.s
 SRCS		:= kernel.c terminal.c utils.c vga.c printf.c keyboard.c debug.c reboot.c gdt.c panic.c init.c mm.c memory.c \
-				ordered_array.c
+				ordered_array.c kmalloc.c
 OBJS_DIR	:= objs/
 OBJSNAME	:= $(SRCS:.c=.o)
 OBJS		:= $(SRCS:%.c=$(OBJS_DIR)%.o)

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -57,7 +57,7 @@ typedef struct
 
 typedef struct
 {
-	uint32_t header;
+	header_t *header;
 	uint32_t magic;
 } footer_t;
 

--- a/includes/mm.h
+++ b/includes/mm.h
@@ -73,5 +73,7 @@ uint32_t	get_frame();
 void		alloc_frame(uint32_t *page);
 uint32_t	*get_page(uint32_t addr);
 heap_t		*init_heap(uint32_t size, uint32_t max_addr, uint8_t is_user, uint8_t is_write);
+void		*kmalloc(uint32_t size);
+void		*kmalloc_ap(uint32_t size, uint32_t *phys);
 
 #endif

--- a/includes/ordered_array.h
+++ b/includes/ordered_array.h
@@ -15,5 +15,6 @@ typedef struct ordered_array
 ordered_array_t init_ordered_array(void *start, uint32_t max_size, lessthan_predic_t less);
 void insert_ordered_array(type_t item, ordered_array_t *arr);
 type_t select_ordered_array(uint32_t idx, ordered_array_t *arr);
+void delete_ordered_array(uint32_t idx, ordered_array_t *arr);
 
 #endif

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -9,7 +9,7 @@ int		printf(const char *, ...);
 size_t	strlen(const char*);
 void	*memcpy(void *, const void *, size_t);
 int		strncmp(const char *, const char *, size_t);
-void	memset(uint8_t *dest, uint8_t val, uint32_t len);
+void	memset(void *dest, uint8_t val, uint32_t len);
 
 void	reboot();
 

--- a/srcs/kmalloc.c
+++ b/srcs/kmalloc.c
@@ -1,0 +1,62 @@
+#include "utils.h"
+#include "mm.h"
+
+extern heap_t *kheap;
+
+uint32_t find_hole(uint32_t size, uint8_t align)
+{
+	uint32_t iter = 0;
+	while (iter < kheap->arr.size)
+	{
+		header_t *header = select_ordered_array(iter, &kheap->arr);
+		if (align)
+		{
+			uint32_t pos = (uint32_t)header;
+			int32_t offset = 0;
+			if ((pos + sizeof(header_t)) & 0x00000FFF)
+				offset = 0x1000 - ((pos + sizeof(header_t)) % 0x1000);
+			// 정렬된 위치에 할당되어야함. 이용가능한 크기 - 정렬하느라 건너 뛴 크기
+			int32_t hole_size = (int32_t)header->size - offset; 
+			if ((int32_t)size <= hole_size)
+				break;
+		}
+		else if (size <= header->size)
+			break ;
+		iter++;
+	}
+	if (iter == kheap->arr.size)
+		return -1;
+	return iter;
+}
+
+static void *alloc(uint32_t size, uint8_t align)
+{
+	uint32_t new_size = size + sizeof(header_t) + sizeof(footer_t); 
+	uint32_t iter = find_hole(size, align);
+	if (iter == -1)
+	{
+		expand();
+		return alloc(size, align);
+	}
+}
+
+static void *kmalloc_init(uint32_t size, uint8_t align, uint32_t *phys)
+{
+	void *addr = alloc(size, align);
+	if (phys)
+	{
+		uint32_t page = (uint32_t)get_page((uint32_t)addr);
+		*phys = page & 0xFFFFF000;
+	}
+	return addr;
+}
+
+void  *kmalloc(uint32_t size)
+{
+	return kmalloc_init(size, 0, 0);
+}
+
+void *kmalloc_ap(uint32_t size, uint32_t *phys)
+{
+	return kmalloc_init(size, 1, phys);
+}

--- a/srcs/kmalloc.c
+++ b/srcs/kmalloc.c
@@ -61,7 +61,7 @@ static void *alloc(uint32_t size, uint8_t align)
 		expand(length + size);
 		uint32_t new_length = kheap->end_addr - kheap->start_addr;
 		iter = 0;
-		uint32_t idx = ARRAY_IDX_SIZE + 1;
+		uint32_t idx = -1;
 		uint32_t val = 0x0; // block
 		while (iter < kheap->arr.size)
 		{
@@ -73,7 +73,7 @@ static void *alloc(uint32_t size, uint8_t align)
 			}
 			iter++;
 		}
-		if (idx == ARRAY_IDX_SIZE + 1)
+		if (idx == -1)
 		{
 			header_t *header = (header_t *)end_addr;
 			header->is_hole = 1;
@@ -99,7 +99,7 @@ static void *alloc(uint32_t size, uint8_t align)
 	uint32_t hole_loc = (uint32_t)target_hole;
 	uint32_t hole_size = target_hole->size;
 	
-	// 요청된 크기만큼 나눠준 후에 hole의 크기가 header와 footer의 크기 합 보다 작은 경우 
+	// 요청된 크기만큼 나눠준 후, hole의 크기가 header와 footer의 크기 합 보다 작은 경우
 	if (hole_size - new_size < sizeof(header_t) + sizeof(footer_t))
 	{
 		size += hole_size - new_size;
@@ -108,20 +108,18 @@ static void *alloc(uint32_t size, uint8_t align)
 	if (align && (hole_loc & 0xFFFFF000))
 	{
 		uint32_t new_loc = hole_loc - (hole_loc & 0xFFF) + 0x1000 - sizeof(header_t);
-		header_t *header = (header_t *)hole_loc;
-		header->size = 0x1000 - (hole_loc & 0xFFF) - sizeof(header_t);
-		header->magic = HEAP_MAGIC;
-		header->is_hole = 1;
+		target_hole->size = 0x1000 - (hole_loc & 0xFFF) - sizeof(header_t);
 		footer_t *footer = (footer_t *)(new_loc - sizeof(footer_t));
-		footer->header = header;
+		footer->header = target_hole;
 		footer->magic = HEAP_MAGIC;
 		hole_loc = new_loc;
-		hole_size -= header->size;
+		hole_size -= target_hole->size;
 	}
 	else
 	{
 		delete_ordered_array(iter, &kheap->arr);
 	}
+	
 	header_t *block_header = (header_t *)hole_loc;
 	block_header->is_hole = 1;
 	block_header->size = new_size;
@@ -130,6 +128,25 @@ static void *alloc(uint32_t size, uint8_t align)
 	block_footer->header = block_header;
 	block_footer->magic = HEAP_MAGIC;
 
+	// hole의 크기가 block의 크기보다 작을 때, hole 만들기
+	if (hole_size - block_header->size > 0)
+	{
+		header_t *header = (header_t *)(hole_loc + block_header->size);
+		header->is_hole = 1;
+		header->magic = HEAP_MAGIC;
+		header->size = hole_size - block_header->size;
+		footer_t *footer = (footer_t *)(hole_loc + header->size - sizeof(footer_t));
+		if ((uint32_t)footer + sizeof(footer_t) >= kheap->end_addr)
+		{
+			uint32_t length = kheap->end_addr - kheap->start_addr;
+			uint32_t size = (uint32_t)footer - kheap->end_addr + sizeof(footer_t);
+			expand(length+size);
+		}
+		footer->header= header;
+		footer->magic = HEAP_MAGIC;
+		insert_ordered_array((type_t)header, &kheap->arr);
+	}
+	return (void *)((uint32_t)block_header + sizeof(header_t));
 }
 
 static void *kmalloc_init(uint32_t size, uint8_t align, uint32_t *phys)

--- a/srcs/memory.c
+++ b/srcs/memory.c
@@ -76,9 +76,10 @@ uint32_t *get_page(uint32_t addr)
 	uint32_t tbl_off = addr20 & 0x3ff;
 	if (!pgdir->tables[dir_off]) // 테이블이 없는 경우
 	{
-		uint32_t tmp = var_partition(sizeof(page_tbl_t)); // TODO kmalloc
-		pgdir->entries[dir_off] = V2P(tmp) | 0x3;
-		memset(pgdir->entries[dir_off], 0, 0x1000U);
+		uint32_t tmp;
+		pgdir->tables[dir_off] = (page_tbl_t *)kmalloc_ap(sizeof(page_tbl_t), &tmp);
+		memset(pgdir->tables[dir_off], 0, sizeof(page_tbl_t));
+		pgdir->entries[dir_off] = tmp | 0x3;
 	}
 	return &(pgdir->tables[dir_off]->entries[tbl_off]);
 }

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -28,64 +28,6 @@ void test()
 	alloc_frame(get_page(0xC0201000));
 }
 
-uint32_t find_hole(uint32_t size, uint8_t align)
-{
-	uint32_t iter = 0;
-	while (iter < kheap->arr.size)
-	{
-		header_t *header = select_ordered_array(iter, &kheap->arr);
-		if (align)
-		{
-			uint32_t pos = (uint32_t)header;
-			int32_t offset = 0;
-			if ((pos + sizeof(header_t)) & 0x00000FFF)
-				offset = 0x1000 - ((pos + sizeof(header_t)) % 0x1000);
-			// 정렬된 위치에 할당되어야함. 이용가능한 크기 - 정렬하느라 건너 뛴 크기
-			int32_t hole_size = (int32_t)header->size - offset; 
-			if ((int32_t)size <= hole_size)
-				break;
-		}
-		else if (size <= header->size)
-			break ;
-		iter++;
-	}
-	if (iter == kheap->arr.size)
-		return -1;
-	return iter;
-}
-
-static void *alloc(uint32_t size, uint8_t align)
-{
-	uint32_t new_size = size + sizeof(header_t) + sizeof(footer_t); 
-	uint32_t iter = find_hole(size, align);
-	if (iter == -1)
-	{
-		expand();
-		return alloc(size, align);
-	}
-}
-
-static void *kmalloc_init(uint32_t size, uint8_t align, uint32_t *phys)
-{
-	void *addr = alloc(size, align);
-	if (phys)
-	{
-		uint32_t page = (uint32_t)get_page((uint32_t)addr);
-		*phys = page & 0xFFFFF000;
-	}
-	return addr;
-}
-
-void  *kmalloc(uint32_t size)
-{
-	return kmalloc_init(size, 0, 0);
-}
-
-void *kmalloc_ap(uint32_t size, uint32_t *phys)
-{
-	return kmalloc_init(size, 1, phys);
-}
-
 void mem_init()
 {
 	mmi.nframes = mmi.totsz / 0x1000;

--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -28,6 +28,64 @@ void test()
 	alloc_frame(get_page(0xC0201000));
 }
 
+uint32_t find_hole(uint32_t size, uint8_t align)
+{
+	uint32_t iter = 0;
+	while (iter < kheap->arr.size)
+	{
+		header_t *header = select_ordered_array(iter, &kheap->arr);
+		if (align)
+		{
+			uint32_t pos = (uint32_t)header;
+			int32_t offset = 0;
+			if ((pos + sizeof(header_t)) & 0x00000FFF)
+				offset = 0x1000 - ((pos + sizeof(header_t)) % 0x1000);
+			// 정렬된 위치에 할당되어야함. 이용가능한 크기 - 정렬하느라 건너 뛴 크기
+			int32_t hole_size = (int32_t)header->size - offset; 
+			if ((int32_t)size <= hole_size)
+				break;
+		}
+		else if (size <= header->size)
+			break ;
+		iter++;
+	}
+	if (iter == kheap->arr.size)
+		return -1;
+	return iter;
+}
+
+static void *alloc(uint32_t size, uint8_t align)
+{
+	uint32_t new_size = size + sizeof(header_t) + sizeof(footer_t); 
+	uint32_t iter = find_hole(size, align);
+	if (iter == -1)
+	{
+		expand();
+		return alloc(size, align);
+	}
+}
+
+static void *kmalloc_init(uint32_t size, uint8_t align, uint32_t *phys)
+{
+	void *addr = alloc(size, align);
+	if (phys)
+	{
+		uint32_t page = (uint32_t)get_page((uint32_t)addr);
+		*phys = page & 0xFFFFF000;
+	}
+	return addr;
+}
+
+void  *kmalloc(uint32_t size)
+{
+	return kmalloc_init(size, 0, 0);
+}
+
+void *kmalloc_ap(uint32_t size, uint32_t *phys)
+{
+	return kmalloc_init(size, 1, phys);
+}
+
 void mem_init()
 {
 	mmi.nframes = mmi.totsz / 0x1000;

--- a/srcs/ordered_array.c
+++ b/srcs/ordered_array.c
@@ -41,3 +41,13 @@ type_t select_ordered_array(uint32_t idx, ordered_array_t *arr)
 		panic_1("check arr_size, idx");
 	return arr->arr[idx];
 }
+
+void delete_ordered_array(uint32_t idx, ordered_array_t *arr)
+{
+	while (idx < arr->size)
+	{
+		arr->arr[idx] = arr->arr[idx + 1];
+		idx++;
+	}
+	arr->size--;
+}

--- a/srcs/utils.c
+++ b/srcs/utils.c
@@ -41,8 +41,8 @@ int	strncmp(const char *s1, const char *s2, size_t n)
 }
 
 // Write len copies of val into dest.
-void memset(uint8_t *dest, uint8_t val, uint32_t len)
+void memset(void *dest, uint8_t val, uint32_t len)
 {
-    uint8_t *temp = (uint8_t *)dest;
+    char *temp = (char*)dest;
     for ( ; len != 0; len--) *temp++ = val;
 }


### PR DESCRIPTION
#59 
- void *kmalloc(uint32_t sz);
  - alloc을 호출하는 함수
  - 페이지 테이블을 생성할 때에는 kmalloc_ap(4KB를 확보하는 할당)
  
- void *alloc(uint32_t sz, uint8_t align);
  - hole을 ordered array로 관리
  - 요청된 크기에 적합한 hole이 없다면 expand
  - align이 요청되는 경우 -> align을 제외한 크기의 hole 추가
  - hole의 크기보다 작게 요청되는 경우 -> 요청된 크기를 제외한 hole 추가
  - block은 oredered_array에 추가 x
