### PR TITLE
fix: set bit(i * 0x1000 -> i)

### DIFF
--- a/srcs/mm.c
+++ b/srcs/mm.c
@@ -35,7 +35,7 @@ void mem_init()
 	memset(mmi.frames, 0, IDX_FRAME(mmi.nframes));
 	for (uint32_t i = 0x0; i < (uint32_t)&_mapping_size; i += 0x1000U)
 	{
-		set_bit(i * 0x1000U);
+		set_bit(i);
 	}
 	// test();
 	kheap = init_heap(0x10000, 0xFFFFE000, 0, 1);


### PR DESCRIPTION
### get_frame 시, 프레임 1000 부터 할당되는 문제
- frame 초기화 과정에서 set_bit를 설정 시, i 값은 이미 frame_addr 형태
- set_bit(i * 0x1000) -> set_bit(i) 로 수정
